### PR TITLE
Add Browser UI for Orca + Server Docs + CLI Enhancements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ coverage.xml
 
 # Sphinx documentation
 docs/_build/
+
+# Node dependencies
+node_modules/

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ install:
 - >
   conda create -q -n test-environment
   python=$TRAVIS_PYTHON_VERSION
-  cytoolz flask pandas pip pygments pytables pytest
+  cytoolz flask pandas pip pygments pytables pytest six
 - source activate test-environment
 - pip install zbox
 - pip install pytest-cov coveralls pep8

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -135,6 +135,11 @@ Orca may also be installed with conda::
 
 (The jiffyclub channel is included for install zbox.)
 
+Add the server option to include the optional server dependencies::
+
+    pip install orca[server]
+
+
 Links
 -----
 
@@ -148,6 +153,7 @@ Contents
    :maxdepth: 2
 
    core
+   server
    utils
 
 Indices and tables

--- a/docs/server.rst
+++ b/docs/server.rst
@@ -1,0 +1,562 @@
+Orca Server
+===========
+
+Orca ships with a `Flask <http://flask.pocoo.org/>`__ server that can
+provide data about and from an Orca configuration.
+You can use it as a zero-configuration server for your data use the
+bundled UI to browse an Orca configuration.
+
+Requirements
+------------
+
+The Orca server requires three additional libraries:
+
+* `Flask <http://flask.pocoo.org/>`__ >= 0.10
+* `Pygments <http://pygments.org/>`__ >= 2.0
+* `Six <http://pythonhosted.org/six/>`__ >= 1.9
+
+You can get these libraries individually (they are available via
+`pip <https://pip.pypa.io/en/stable/>`__ and
+`conda <http://conda.pydata.org/>`__), or get them when you install
+Orca by including the ``[server]`` option::
+
+    pip install orca[server]
+
+Start the Server
+----------------
+
+Use the ``orca-server`` command line utility to start the Orca server::
+
+    > orca-server --help
+    usage: orca-server [-h] [-d] [-H HOST] [-p PORT] filename
+
+    Start a Flask server that has HTTP endpoints that provide data about an Orca
+    configuration and data registered with Orca.
+
+    positional arguments:
+      filename              File with Orca config
+
+    optional arguments:
+      -h, --help            show this help message and exit
+      -d, --debug           Enable Flask's debug mode
+      -H HOST, --host HOST  Hostname on which to run the server
+      -p PORT, --port PORT  Port on which to run server
+
+The ``filename`` argument is the name of a Python file that will be imported
+by the server in order to populate Orca.
+Refer to the documentation of Flask's
+`run method <http://flask.pocoo.org/docs/0.10/api/#flask.Flask.run>`__
+to learn more about the debug, host, and port options.
+
+Server Routes
+-------------
+
+This section details the routes available from the Orca server.
+Most of the routes return JSON, but some return text as noted in
+the descriptions.
+
+.. contents::
+   :local:
+
+UI
+~~
+
+* Route: ``/ui``
+* Returns: HTML
+
+The ``/ui`` route is meant for use with browsers and allows the user to
+browse their Orca configuration.
+Users can see lists of registered items, data previews, summary statistics,
+and the source code definitions of functions registered with Orca.
+
+.. note::
+
+   Using the Orca browser requires an internet connection so the application
+   can load some third-party CSS and JavaScript.
+
+Schema
+~~~~~~
+
+* Route: ``/schema``
+* Returns: JSON
+
+The "schema" route returns a complete list of available tables, columns, steps,
+injectables, and broadcasts.
+Columns include both those registered on a table via Orca and those that
+are local to a table.
+The returned JSON object has keys ``tables``, ``steps``, ``injectables``,
+``columns``, and ``broadcasts``.
+The ``tables``, ``steps`` and ``injectables`` values are arrays of strings.
+The ``injectables`` value is an array of two-value arrays with the names
+of the "cast" and "onto" tables, respectively.
+The ``columns`` value is an object whose keys are table names and values
+are arrays of strings (column names).
+
+Example:
+
+.. code-block:: json
+
+    {
+      "tables": ["my_table", "another_table"],
+      "columns": {
+        "my_table": ["col1", "col2", "col3"],
+        "another_table": ["data1", "data2"]
+      },
+      "injectables": ["val1", "val2"],
+      "steps": ["process_data"],
+      "broadcasts": [["my_table", "another_table"]]
+    }
+
+List Tables
+~~~~~~~~~~~
+
+* Route: ``/tables``
+* Returns: JSON
+
+The "tables" route returns a list of the tables registered with Orca.
+
+.. code-block:: json
+
+    {
+      "tables": ["my_table", "another_table"]
+    }
+
+Table Info
+~~~~~~~~~~
+
+* Route: ``/tables/<table_name>/info``
+* Returns: Text
+
+Returns the text result of ``table.info(verbose=True)``::
+
+    <class 'pandas.core.frame.DataFrame'>
+    Int64Index: 2478 entries, 0 to 2477
+    Data columns (total 10 columns):
+    region          2478 non-null object
+    subregion       2478 non-null object
+    station         2478 non-null object
+    abbreviation    2478 non-null object
+    elevation       2478 non-null int64
+    month           2478 non-null object
+    precip          1869 non-null float64
+    avg precip      2466 non-null float64
+    pct of avg      1953 non-null float64
+    year            2478 non-null int64
+    dtypes: float64(3), int64(2), object(5)
+    memory usage: 213.0+ KB
+
+Table Preview
+~~~~~~~~~~~~~
+
+* Route: ``/tables/<table_name>/preview``
+* Returns: JSON
+
+Returns the result of ``table.head()`` as JSON in Pandas' "split" format.
+
+.. code-block:: json
+
+    {
+      "columns": ["col1", "col2"],
+      "data": [
+        ["datum1", 19],
+        ["datum2", 42],
+        ["datum3", 99]
+      ],
+      "index": [12, 26, 40]
+    }
+
+Table Describe
+~~~~~~~~~~~~~~
+
+* Route: ``/tables/<table_name>/describe``
+* Returns: JSON
+
+Returns the result of ``table.describe()`` as JSON in Pandas' "split" format.
+
+.. code-block:: json
+
+    {
+      "columns": [
+        "elevation",
+        "precip",
+      ],
+      "data": [
+        [
+          177.0,
+          98.0
+        ],
+        [
+          2782.581920904,
+          15.3412244898
+        ],
+        [
+          2540.805957787,
+          11.8787421898
+        ],
+        [
+          -194.0,
+          1.49
+        ],
+        [
+          384.0,
+          5.6075
+        ],
+        [
+          2400.0,
+          12.465
+        ],
+        [
+          4641.0,
+          20.4625
+        ],
+        [
+          9645.0,
+          60.91,
+        ],
+      ],
+      "index": [
+        "count",
+        "mean",
+        "std",
+        "min",
+        "25%",
+        "50%",
+        "75%",
+        "max"
+      ]
+    }
+
+Table Definition
+~~~~~~~~~~~~~~~~
+
+* Route: ``/tables/<table_name>/definition``
+* Returns: JSON
+
+Get information about how a table is registered with Orca, for example whether
+it is a registered DataFrame or function.
+If the table is a registered function this returns the text of the function.
+
+If the table is a registered DataFrame all that is returned is:
+
+.. code-block:: json
+
+    {"type": "dataframe"}
+
+If the table is registered as a function the returned data will include the
+filename, line number, and text of the function:
+
+.. code-block:: json
+
+    {
+      "type": "function",
+      "filename": "data.py",
+      "lineno": 42,
+      "text": "function text",
+      "html": "function text as html"
+    }
+
+The HTML has been marked up by `Pygments <http://pygments.org/>`__ with the
+``.highlight`` class.
+
+Table CSV
+~~~~~~~~~
+
+* Route: ``/tables/<table_name>/csv``
+* Returns: Text
+
+Returns the entire table as CSV using Pandas' default CSV output.
+
+::
+
+    ,col1,col2
+    12,datum1,19
+    26,datum2,42
+    40,datum3,99
+
+Table Groupby Aggregation
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* Route: ``/tables/<table_name>/groupbyagg``
+* Returns: JSON
+
+The groupby-agg API allows clients to perform a groupby on a table, then
+an aggregation on a single column and get the resulti as JSON
+in Pandas' "split" format.
+
+The parameters of the groupby-agg are specified as URL parameters:
+
+* `column` - Column to aggregate
+* `agg` - Aggregation to perform. Supported values are `mean`, `median`,
+  `std`, `sum`, and `size`.
+* `by` (optional) - Column on which to group table
+* `level` (optional) - Index level on which to group table
+
+One of `by` or `level` must be provided, but not both.
+For example, the URL might read::
+
+    /groupbyagg?by=region&column=precip&agg=median
+
+The data is returned as JSON in Pandas' "split" format:
+
+.. code-block:: json
+
+    {
+      "data": [10.225, 2.15],
+      "index": ["CENTRAL COAST", "COLORADO RIVER"],
+      "name": "precip"
+    }
+
+List Columns For Table
+~~~~~~~~~~~~~~~~~~~~~~
+
+* Route: ``/tables/<table_name>/columns``
+* Returns: JSON
+
+List all columns for a table including both local and registered columns.
+
+.. code-block:: json
+
+    {
+      "columns": ["col1", "col2"]
+    }
+
+Column Preview
+~~~~~~~~~~~~~~
+
+* Route: ``/tables/<table_name>/columns/<column_name>/preview``
+* Returns: JSON
+
+Return the first ten elements of a column as JSON in Pandas' "split" format:
+
+.. code-block:: json
+
+    {
+      "data": [60.92, 12.63, 12.06, 12.11, 26.08],
+      "index": [12, 26, 40, 54, 68],
+      "name": "precip"
+    }
+
+Column Definition
+~~~~~~~~~~~~~~~~~
+
+* Route: ``/tables/<table_name>/columns/<column_name>/definition``
+* Returns: JSON
+
+Get information about how a column is registered with Orca, for example whether
+it is a registered Series or function.
+If the column is a registered function this returns the text of the function.
+
+If the column is a registered Series all that is returned is:
+
+.. code-block:: json
+
+    {"type": "series"}
+
+or if the column is local to a DataFrame the return value is:
+
+.. code-block:: json
+
+    {"type": "local"}
+
+If the column is registered as a function the returned data will include the
+filename, line number, and text of the function:
+
+.. code-block:: json
+
+    {
+      "type": "function",
+      "filename": "data.py",
+      "lineno": 42,
+      "text": "function text",
+      "html": "function text as html"
+    }
+
+The HTML has been marked up by `Pygments <http://pygments.org/>`__ with the
+``.highlight`` class.
+
+Column Describe
+~~~~~~~~~~~~~~~
+
+* Route: ``/tables/<table_name>/columns/<column_name>/describe``
+* Returns: JSON
+
+Return summary statistics for a column as JSON in Pandas' "split" format:
+
+.. code-block:: json
+
+    {
+      "data": [
+        1771.0,
+        1.3995482778,
+        2.508358979,
+        0.0,
+        0.07,
+        0.57,
+        1.445,
+        21.34
+      ],
+      "index": [
+        "count",
+        "mean",
+        "std",
+        "min",
+        "25%",
+        "50%",
+        "75%",
+        "max"
+      ],
+      "name": "precip"
+    }
+
+Column CSV
+~~~~~~~~~~
+
+* Route: ``/tables/<table_name>/columns/<column_name>/csv``
+* Returns: Text
+
+Return an entire column as CSV using Pandas' default output::
+
+    0,0.04
+    1,5.02
+    2,2.35
+    3,3.72
+    4,19.48
+
+List Injectables
+~~~~~~~~~~~~~~~~
+
+* Route: ``/injectables``
+* Returns: JSON
+
+Returns a list of all registered injectables:
+
+.. code-block:: json
+
+    {
+      "injectables": ["var1", "var2"]
+    }
+
+Injectable Repr
+~~~~~~~~~~~~~~~
+
+* Route: ``/injectables/<injectable_name>/repr``
+* Returns: JSON
+
+Return the string representations of an injectable and the type of an
+injectable:
+
+.. code-block:: json
+
+    {
+      "repr": "2014",
+      "type": "<class 'int'>"
+    }
+
+This will attempt to return the entire string representation of a value.
+Use care with variables where that might be large.
+
+Injectable Definition
+~~~~~~~~~~~~~~~~~~~~~
+
+* Route: ``/injectables/<injectable_name>/definition``
+* Returns: JSON
+
+Get the definition of an injectable. If the injectable is anything other
+than a function the result will be:
+
+.. code-block:: json
+
+    {
+      "type": "variable"
+    }
+
+If the injectable is a function the returned data will include the
+filename, line number, and text of the function:
+
+.. code-block:: json
+
+    {
+      "type": "function",
+      "filename": "data.py",
+      "lineno": 42,
+      "text": "function text",
+      "html": "function text as html"
+    }
+
+The HTML has been marked up by `Pygments <http://pygments.org/>`__ with the
+``.highlight`` class.
+
+List Broadcasts
+~~~~~~~~~~~~~~~
+
+* Route: ``/broadcasts``
+* Returns: JSON
+
+List all registered broadcasts as objects with "cast" and "onto" keys:
+
+.. code-block:: json
+
+    {
+      "broadcasts": [
+        {"cast": "table1", "onto": "table2"},
+        {"cast": "table3", "onto": "table2"}
+      ]
+    }
+
+Broadcast Definition
+~~~~~~~~~~~~~~~~~~~~
+
+* Route: ``/broadcasts/<cast_name>/<onto_name>/definition``
+* Returns: JSON
+
+Get the definition of a broadcast, which is essentially the arguments that
+were passed to the :py:func:`~orca.orca.broadcast` function to register
+the broadcast:
+
+.. code-block:: json
+
+    {
+      "cast": "table1",
+      "cast_index": false,
+      "cast_on": "onto_id",
+      "onto": "table2",
+      "onto_index": true,
+      "onto_on": null
+    }
+
+List Steps
+~~~~~~~~~~
+
+* Route: ``/steps``
+* Returns: JSON
+
+Returns a list of registered step names:
+
+.. code-block:: json
+
+  {
+    "steps": ["concat_yearly", "concat_monthly"]
+  }
+
+Step Definition
+~~~~~~~~~~~~~~~
+
+* Route: ``/steps/<step_name>/definition``
+* Returns: JSON
+
+Get the source of a step function.
+The returned data will include the
+filename, line number, and text of the function:
+
+.. code-block:: json
+
+    {
+      "type": "function",
+      "filename": "data.py",
+      "lineno": 42,
+      "text": "function text",
+      "html": "function text as html"
+    }
+
+The HTML has been marked up by `Pygments <http://pygments.org/>`__ with the
+``.highlight`` class.

--- a/orca/server/server.py
+++ b/orca/server/server.py
@@ -254,6 +254,22 @@ def list_table_columns(table_name):
     return jsonify(columns=orca.get_table(table_name).columns)
 
 
+@app.route('/tables/<table_name>/columns/<col_name>/preview')
+@check_is_column
+def column_preview(table_name, col_name):
+    """
+    Return the first ten elements of a column as JSON in Pandas'
+    "split" format.
+
+    """
+    col = orca.get_table(table_name).get_column(col_name).head(10)
+
+    return (
+        col.to_json(orient='split', date_format='iso'),
+        200,
+        {'Content-Type': 'application/json'})
+
+
 @app.route('/tables/<table_name>/columns/<col_name>/definition')
 @check_is_column
 def column_definition(table_name, col_name):

--- a/orca/server/server.py
+++ b/orca/server/server.py
@@ -458,6 +458,13 @@ def parse_args(args=None):
         description=(
             'Start a Flask server that has HTTP endpoints that provide data '
             'about an Orca configuration and data registered with Orca.'))
+    parser.add_argument(
+        '-d', '--debug', action='store_true',
+        help='Enable Flask\'s debug mode')
+    parser.add_argument(
+        '-H', '--host', type=str, help='Hostname on which to run the server')
+    parser.add_argument(
+        '-p', '--port', type=int, help='Port on which to run server')
     parser.add_argument('filename', type=str, help='File with Orca config')
     return parser.parse_args(args)
 
@@ -465,4 +472,4 @@ def parse_args(args=None):
 def main(args=None):
     args = parse_args(args)
     import_file(args.filename)
-    app.run(debug=True)
+    app.run(host=args.host, port=args.port, debug=args.debug)

--- a/orca/server/server.py
+++ b/orca/server/server.py
@@ -6,7 +6,8 @@ from functools import wraps
 from operator import methodcaller
 
 import orca
-from flask import Flask, abort, jsonify, request
+from flask import (
+    Flask, abort, jsonify, request, render_template, redirect, url_for)
 from pygments import highlight
 from pygments.lexers import PythonLexer
 from pygments.formatters import HtmlFormatter
@@ -409,6 +410,16 @@ def step_definition(step_name):
         orca.get_step(step_name).func_source_data()
     html = highlight(source, PythonLexer(), HtmlFormatter())
     return jsonify(filename=filename, lineno=lineno, text=source, html=html)
+
+
+@app.route('/ui')
+def ui():
+    return render_template('ui.html')
+
+
+@app.route('/')
+def root():
+    return redirect(url_for('ui'))
 
 
 def parse_args(args=None):

--- a/orca/server/server.py
+++ b/orca/server/server.py
@@ -11,6 +11,7 @@ from flask import (
 from pygments import highlight
 from pygments.lexers import PythonLexer
 from pygments.formatters import HtmlFormatter
+from six import StringIO
 
 app = Flask(__name__)
 
@@ -118,6 +119,20 @@ def list_tables():
     """
     tables = orca.list_tables()
     return jsonify(tables=tables)
+
+
+@app.route('/tables/<table_name>/info')
+@check_is_table
+def table_info(table_name):
+    """
+    Return the text result of table.info(verbose=True).
+
+    """
+    table = orca.get_table(table_name).to_frame()
+    buf = StringIO()
+    table.info(verbose=True, buf=buf)
+    info = buf.getvalue()
+    return info, 200, {'Content-Type': 'text/plain'}
 
 
 @app.route('/tables/<table_name>/preview')

--- a/orca/server/static/css/pygments.css
+++ b/orca/server/static/css/pygments.css
@@ -1,0 +1,63 @@
+.highlight .hll { background-color: #ffffcc }
+.highlight  { background: #f8f8f8; }
+.highlight .c { color: #408080; font-style: italic } /* Comment */
+.highlight .err { border: 1px solid #FF0000 } /* Error */
+.highlight .k { color: #008000; font-weight: bold } /* Keyword */
+.highlight .o { color: #666666 } /* Operator */
+.highlight .cm { color: #408080; font-style: italic } /* Comment.Multiline */
+.highlight .cp { color: #BC7A00 } /* Comment.Preproc */
+.highlight .c1 { color: #408080; font-style: italic } /* Comment.Single */
+.highlight .cs { color: #408080; font-style: italic } /* Comment.Special */
+.highlight .gd { color: #A00000 } /* Generic.Deleted */
+.highlight .ge { font-style: italic } /* Generic.Emph */
+.highlight .gr { color: #FF0000 } /* Generic.Error */
+.highlight .gh { color: #000080; font-weight: bold } /* Generic.Heading */
+.highlight .gi { color: #00A000 } /* Generic.Inserted */
+.highlight .go { color: #888888 } /* Generic.Output */
+.highlight .gp { color: #000080; font-weight: bold } /* Generic.Prompt */
+.highlight .gs { font-weight: bold } /* Generic.Strong */
+.highlight .gu { color: #800080; font-weight: bold } /* Generic.Subheading */
+.highlight .gt { color: #0044DD } /* Generic.Traceback */
+.highlight .kc { color: #008000; font-weight: bold } /* Keyword.Constant */
+.highlight .kd { color: #008000; font-weight: bold } /* Keyword.Declaration */
+.highlight .kn { color: #008000; font-weight: bold } /* Keyword.Namespace */
+.highlight .kp { color: #008000 } /* Keyword.Pseudo */
+.highlight .kr { color: #008000; font-weight: bold } /* Keyword.Reserved */
+.highlight .kt { color: #B00040 } /* Keyword.Type */
+.highlight .m { color: #666666 } /* Literal.Number */
+.highlight .s { color: #BA2121 } /* Literal.String */
+.highlight .na { color: #7D9029 } /* Name.Attribute */
+.highlight .nb { color: #008000 } /* Name.Builtin */
+.highlight .nc { color: #0000FF; font-weight: bold } /* Name.Class */
+.highlight .no { color: #880000 } /* Name.Constant */
+.highlight .nd { color: #AA22FF } /* Name.Decorator */
+.highlight .ni { color: #999999; font-weight: bold } /* Name.Entity */
+.highlight .ne { color: #D2413A; font-weight: bold } /* Name.Exception */
+.highlight .nf { color: #0000FF } /* Name.Function */
+.highlight .nl { color: #A0A000 } /* Name.Label */
+.highlight .nn { color: #0000FF; font-weight: bold } /* Name.Namespace */
+.highlight .nt { color: #008000; font-weight: bold } /* Name.Tag */
+.highlight .nv { color: #19177C } /* Name.Variable */
+.highlight .ow { color: #AA22FF; font-weight: bold } /* Operator.Word */
+.highlight .w { color: #bbbbbb } /* Text.Whitespace */
+.highlight .mb { color: #666666 } /* Literal.Number.Bin */
+.highlight .mf { color: #666666 } /* Literal.Number.Float */
+.highlight .mh { color: #666666 } /* Literal.Number.Hex */
+.highlight .mi { color: #666666 } /* Literal.Number.Integer */
+.highlight .mo { color: #666666 } /* Literal.Number.Oct */
+.highlight .sb { color: #BA2121 } /* Literal.String.Backtick */
+.highlight .sc { color: #BA2121 } /* Literal.String.Char */
+.highlight .sd { color: #BA2121; font-style: italic } /* Literal.String.Doc */
+.highlight .s2 { color: #BA2121 } /* Literal.String.Double */
+.highlight .se { color: #BB6622; font-weight: bold } /* Literal.String.Escape */
+.highlight .sh { color: #BA2121 } /* Literal.String.Heredoc */
+.highlight .si { color: #BB6688; font-weight: bold } /* Literal.String.Interpol */
+.highlight .sx { color: #008000 } /* Literal.String.Other */
+.highlight .sr { color: #BB6688 } /* Literal.String.Regex */
+.highlight .s1 { color: #BA2121 } /* Literal.String.Single */
+.highlight .ss { color: #19177C } /* Literal.String.Symbol */
+.highlight .bp { color: #008000 } /* Name.Builtin.Pseudo */
+.highlight .vc { color: #19177C } /* Name.Variable.Class */
+.highlight .vg { color: #19177C } /* Name.Variable.Global */
+.highlight .vi { color: #19177C } /* Name.Variable.Instance */
+.highlight .il { color: #666666 } /* Literal.Number.Integer.Long */

--- a/orca/server/static/gulpfile.js
+++ b/orca/server/static/gulpfile.js
@@ -14,6 +14,9 @@ var config = {
 };
 
 // for files that need to be run through browserify and reactify
+// Mostly copied from:
+// http://tylermcginnis.com/reactjs-tutorial-pt-2-building-react-applications-with-gulp-and-browserify/
+// https://github.com/gulpjs/gulp/blob/master/docs/recipes/fast-browserify-builds-with-watchify.md
 gulp.task('js', function() {
   var bfy_opts = {
     entries: [config.main],

--- a/orca/server/static/gulpfile.js
+++ b/orca/server/static/gulpfile.js
@@ -1,0 +1,39 @@
+var gulp = require('gulp');
+var gutil = require('gulp-util');
+var source = require('vinyl-source-stream');
+var browserify = require('browserify');
+var watchify = require('watchify');
+var reactify = require('reactify');
+var streamify = require('gulp-streamify');
+var _ = require('lodash');
+
+var config = {
+  main: 'js/main.js',
+  out: 'bundle.js',
+  dest: 'js/dist'
+};
+
+// for files that need to be run through browserify and reactify
+gulp.task('js', function() {
+  var bfy_opts = {
+    entries: [config.main],
+    transform: [reactify],
+    debug: true
+  };
+  _.assign(bfy_opts, watchify.args);
+  var watcher = watchify(browserify(bfy_opts));
+
+  function bundle() {
+    watcher.bundle()
+      .on('error', gutil.log.bind(gutil, 'Browserify Error'))
+      .pipe(source(config.out))
+      .pipe(gulp.dest(config.dest))
+  }
+
+  watcher.on('update', bundle);
+  watcher.on('log', gutil.log);
+
+  return bundle();
+});
+
+gulp.task('default', ['js']);

--- a/orca/server/static/js/broadcast.js
+++ b/orca/server/static/js/broadcast.js
@@ -1,0 +1,66 @@
+var React = require('react');
+
+
+function on_repr(on) {
+  if (on === null) {
+    return 'None';
+  }
+  return "'" + on + "'";
+}
+
+function index_repr(index) {
+  if (index === false) {
+    return 'False'
+  }
+  return 'True'
+}
+
+var BroadcastApp = React.createClass({
+  getInitialState: function() {
+    return {
+      cast: '',
+      onto: '',
+      cast_on: '',
+      onto_on: '',
+      cast_index: '',
+      onto_index: ''
+    };
+  },
+  componentDidMount: function() {
+    var cast = this.props.cast;
+    var onto = this.props.onto;
+
+    $.getJSON('/broadcasts/' + cast + '/' + onto + '/definition')
+      .done(function(data) {
+        this.setState(data);
+      }.bind(this));
+  },
+  render: function() {
+    return (
+      <div className="broadcastApp">
+        <div className="page-header">
+          <h1>{this.state.cast + ' -> ' + this.state.onto}</h1>
+        </div>
+        <div>
+          <p><strong>Cast</strong></p>
+          <p>{this.state.cast}</p>
+        </div>
+        <div>
+          <p><strong>Onto</strong></p>
+          <p>{this.state.onto}</p>
+        </div>
+        <div>
+          <p><strong>With</strong></p>
+          <ul>
+            <li><code>{'cast_on = ' + on_repr(this.state.cast_on)}</code></li>
+            <li><code>{'onto_on = ' + on_repr(this.state.onto_on)}</code></li>
+            <li><code>{'cast_index = ' + index_repr(this.state.cast_index)}</code></li>
+            <li><code>{'onto_index = ' + index_repr(this.state.onto_index)}</code></li>
+          </ul>
+        </div>
+      </div>
+    );
+  }
+});
+
+module.exports = BroadcastApp;

--- a/orca/server/static/js/buttons.js
+++ b/orca/server/static/js/buttons.js
@@ -1,0 +1,51 @@
+var React = require('react');
+var classNames = require('classnames');
+var _ = require('lodash');
+
+
+var ViewButton = React.createClass({
+  clickHandler: function(event) {
+    this.props.clickHandler(this.props.view);
+  },
+  render: function() {
+    var classes = classNames({
+      "viewButton": true,
+      "btn": true,
+      "btn-default": true,
+      "active": this.props.active
+    });
+
+    return (
+      <button
+          type="button"
+          className={classes}
+          onClick={this.clickHandler}>
+        {this.props.text}
+      </button>
+    );
+  }
+});
+
+var ViewButtonGroup = React.createClass({
+  render: function() {
+    var button_els = _.map(this.props.buttons, function(b) {
+      return (
+        <ViewButton
+          text={b.text}
+          view={b.view}
+          key={b.view}
+          active={b.view === this.props.view}
+          clickHandler={this.props.clickHandler}
+        />
+      );
+    }.bind(this));
+
+    return (
+      <div className="viewButtonGroup btn-group" role="group">
+        {button_els}
+      </div>
+    );
+  }
+});
+
+module.exports = ViewButtonGroup;

--- a/orca/server/static/js/column.js
+++ b/orca/server/static/js/column.js
@@ -1,15 +1,113 @@
 var React = require('react');
 var classNames = require('classnames');
 var _ = require('lodash');
+
 var dtopts = require('./dtopts.js');
+var ViewButtonGroup = require('./buttons.js');
+var funcdef = require('./funcdef.js');
+
+
+var ColumnPreview = React.createClass({
+  componentDidMount: function() {
+    var table = this.props.table;
+    var col = this.props.column;
+
+    $.getJSON('/tables/' + table + '/columns/' + col + '/preview')
+      .done(function(data) {
+        $('#preview-table').DataTable(dtopts.series_opts(data));
+      });
+  },
+  render: function() {
+    return (
+      <div className="tablePreview">
+        <table className="display" id="preview-table">
+        </table>
+      </div>);
+  }
+});
+
+var ColumnDefinition = React.createClass({
+  componentDidMount: function() {
+    var table = this.props.table;
+    var col = this.props.column;
+
+    $.getJSON('/tables/' + table + '/columns/' + col + '/definition')
+      .done(function(data) {
+        if (data.type === 'series') {
+          var component = <funcdef.LiteralDefinition text="Series" />;
+        } else if (data.type === 'local') {
+          var component = <funcdef.LiteralDefinition text="Local Column" />;
+        } else if (data.type === 'function') {
+          var component = <funcdef.FuncDefinition funcData={data} />;
+        }
+
+        React.render(component, document.getElementById('column-definition'));
+      });
+  },
+  render: function() {
+    return (
+      <div id="column-definition"></div>
+    );
+  }
+});
+
+var ColumnDescribe = React.createClass({
+  componentDidMount: function() {
+    var table = this.props.table;
+    var col = this.props.column;
+
+    $.getJSON('/tables/' + table + '/columns/' + col + '/describe')
+      .done(function(data) {
+        $('#describe-table').DataTable(dtopts.series_opts(data));
+      });
+  },
+  render: function() {
+    return (
+      <div className="tableDescribe">
+        <table className="display" id="describe-table">
+        </table>
+      </div>
+    );
+  }
+});
 
 var ColumnApp = React.createClass({
+  colButtons: [
+    {text: 'Preview', view: 'preview'},
+    {text: 'Definition', view: 'definition'},
+    {text: 'Describe', view: 'describe'}
+  ],
+  getInitialState: function() {
+    return {view: this.colButtons[0].view};
+  },
+  handleButtonClick: function(view) {
+    if (view !== this.state.view) {
+      this.setState({view: view});
+    }
+  },
   render: function() {
+    var view = this.state.view;
+    var table = this.props.table;
+    var col = this.props.column;
+
+    if (view === 'preview') {
+      var appComponent = <ColumnPreview table={table} column={col} />;
+    } else if (view === 'definition') {
+      var appComponent = <ColumnDefinition table={table} column={col} />;
+    } else if (view === 'describe') {
+      var appComponent = <ColumnDescribe table={table} column={col} />;
+    }
+
     return (
       <div className="columnApp">
         <div className="page-header">
-          <h1>{this.props.table + '.' + this.props.column}</h1>
+          <h1>{table + '.' + col}</h1>
         </div>
+        <ViewButtonGroup
+            buttons={this.colButtons}
+            view={this.state.view}
+            clickHandler={this.handleButtonClick} />
+        {appComponent}
       </div>
     );
   }

--- a/orca/server/static/js/column.js
+++ b/orca/server/static/js/column.js
@@ -1,0 +1,18 @@
+var React = require('react');
+var classNames = require('classnames');
+var _ = require('lodash');
+var dtopts = require('./dtopts.js');
+
+var ColumnApp = React.createClass({
+  render: function() {
+    return (
+      <div className="columnApp">
+        <div className="page-header">
+          <h1>{this.props.table + '.' + this.props.column}</h1>
+        </div>
+      </div>
+    );
+  }
+});
+
+module.exports = ColumnApp;

--- a/orca/server/static/js/dtopts.js
+++ b/orca/server/static/js/dtopts.js
@@ -2,7 +2,7 @@ var _ = require('lodash');
 
 // Make an object of DataTable options from JSON data of a DataFrame
 // in "split" format.
-function dtopts(data) {
+function table_opts(data) {
   var opts = {paging: false};
 
   // Column heading values, including one for the index values
@@ -19,4 +19,15 @@ function dtopts(data) {
   return opts;
 }
 
-module.exports = dtopts;
+function series_opts(data) {
+  var opts = {paging: false};
+
+  opts['data'] = _.map(data.data, function(val, i) {
+    return [data.index[i], val];
+  });
+
+  return opts;
+}
+
+exports.table_opts = table_opts;
+exports.series_opts = series_opts;

--- a/orca/server/static/js/dtopts.js
+++ b/orca/server/static/js/dtopts.js
@@ -22,6 +22,11 @@ function table_opts(data) {
 function series_opts(data) {
   var opts = {paging: false};
 
+  opts['columns'] = [
+    {title: 'Index'},
+    {title: data.name}
+  ];
+
   opts['data'] = _.map(data.data, function(val, i) {
     return [data.index[i], val];
   });

--- a/orca/server/static/js/dtopts.js
+++ b/orca/server/static/js/dtopts.js
@@ -1,0 +1,22 @@
+var _ = require('lodash');
+
+// Make an object of DataTable options from JSON data of a DataFrame
+// in "split" format.
+function dtopts(data) {
+  var opts = {paging: false};
+
+  // Column heading values, including one for the index values
+  opts['columns'] = _.map(data.columns, function(c) {
+    return {title: c};
+  });
+  opts['columns'].unshift({title: 'Index'});
+
+  // Data, including add the index at the front of each row
+  opts['data'] = _.map(data.data, function(row, i) {
+    return [data.index[i]].concat(row);
+  });
+
+  return opts;
+}
+
+module.exports = dtopts;

--- a/orca/server/static/js/funcdef.js
+++ b/orca/server/static/js/funcdef.js
@@ -1,0 +1,26 @@
+// Stuff related to displaying function definitions
+var React = require('react');
+
+
+var LiteralDefinition = React.createClass({
+  render: function() {
+    return (<p className="literalDefinition">{this.props.text}</p>);
+  }
+});
+
+var FuncDefinition = React.createClass({
+  render: function() {
+    var f = this.props.funcData;
+    return (
+      <div className="funcDefinition">
+        <h3>Source</h3>
+        <p><code>{f.filename} @ line: {f.lineno}</code></p>
+        <div dangerouslySetInnerHTML={{__html: this.props.funcData.html}}>
+        </div>
+      </div>
+    );
+  }
+});
+
+exports.LiteralDefinition = LiteralDefinition;
+exports.FuncDefinition = FuncDefinition;

--- a/orca/server/static/js/injectable.js
+++ b/orca/server/static/js/injectable.js
@@ -1,0 +1,92 @@
+var React = require('react');
+
+var ViewButtonGroup = require('./buttons.js');
+var funcdef = require('./funcdef.js');
+
+
+var InjDefinition = React.createClass({
+  componentDidMount: function() {
+    var inj_name = this.props.inj_name;
+
+    $.getJSON('/injectables/' + inj_name + '/definition')
+      .done(function(data) {
+        if (data.type === 'variable') {
+          var component = <funcdef.LiteralDefinition text="Variable" />;
+        } else if (data.type === 'function') {
+          var component = <funcdef.FuncDefinition funcData={data} />;
+        }
+
+        React.render(component, document.getElementById('inj-definition'));
+      });
+  },
+  render: function() {
+    return (<div id="inj-definition"></div>);
+  }
+});
+
+var InjRepr = React.createClass({
+  getInitialState: function() {
+    return {type: '', repr: ''};
+  },
+  componentDidMount: function() {
+    var inj_name = this.props.inj_name;
+
+    $.getJSON('/injectables/' + inj_name + '/repr')
+      .done(function(data) {
+        this.setState(data);
+      }.bind(this));
+  },
+  render: function() {
+    return (
+      <div className="injRepr">
+        <div>
+          <p>Type</p>
+          <p><code>{this.state.type}</code></p>
+        </div>
+        <div>
+          <p>Repr</p>
+          <p><code>{this.state.repr}</code></p>
+        </div>
+      </div>);
+  }
+});
+
+var InjectableApp = React.createClass({
+  viewButtons: [
+    {text: 'Definition', view: 'definition'},
+    {text: 'Repr', view: 'repr'}
+  ],
+  getInitialState: function() {
+    return {view: this.viewButtons[0].view};
+  },
+  handleButtonClick: function(view) {
+    if (view !== this.state.view) {
+      this.setState({view: view});
+    }
+  },
+  render: function() {
+    var view = this.state.view;
+    var inj_name = this.props.inj_name;
+
+    if (view === 'definition') {
+      var appComponent = <InjDefinition inj_name={inj_name} />;
+    } else if (view === 'repr') {
+      var appComponent = <InjRepr inj_name={inj_name} />;
+    }
+
+    return (
+      <div className="injectableApp">
+        <div className="page-header">
+          <h1>{this.props.inj_name}</h1>
+        </div>
+        <ViewButtonGroup
+            buttons={this.viewButtons}
+            view={this.state.view}
+            clickHandler={this.handleButtonClick} />
+        {appComponent}
+      </div>
+    );
+  }
+});
+
+module.exports = InjectableApp;

--- a/orca/server/static/js/main.js
+++ b/orca/server/static/js/main.js
@@ -1,0 +1,1 @@
+require('./routing.js');

--- a/orca/server/static/js/routing.js
+++ b/orca/server/static/js/routing.js
@@ -3,6 +3,7 @@ var React = require('react');
 
 var SchemaApp = require('./schema.js');
 var TableApp = require('./table.js');
+var ColumnApp = require('./column.js');
 
 var router = new Grapnel();
 
@@ -17,4 +18,11 @@ router.get('', function(req) {
 router.get('tables/:table', function(req) {
   var table_name = req.params.table;
   React.render(<TableApp table={table_name} />, content_div());
+});
+
+router.get('tables/:table/columns/:column', function(req) {
+  var table_name = req.params.table;
+  var col_name = req.params.column;
+  React.render(
+    <ColumnApp table={table_name} column={col_name} />, content_div());
 });

--- a/orca/server/static/js/routing.js
+++ b/orca/server/static/js/routing.js
@@ -2,9 +2,19 @@ var Grapnel = require('grapnel');
 var React = require('react');
 
 var SchemaApp = require('./schema.js');
+var TableApp = require('./table.js');
 
 var router = new Grapnel();
 
+function content_div() {
+  return document.getElementById('content');
+}
+
 router.get('', function(req) {
-    React.render(<SchemaApp />, document.getElementById('content'));
+  React.render(<SchemaApp />, content_div());
+});
+
+router.get('tables/:table', function(req) {
+  var table_name = req.params.table;
+  React.render(<TableApp table={table_name} />, content_div());
 });

--- a/orca/server/static/js/routing.js
+++ b/orca/server/static/js/routing.js
@@ -6,6 +6,7 @@ var TableApp = require('./table.js');
 var ColumnApp = require('./column.js');
 var StepApp = require('./step.js');
 var InjectableApp = require('./injectable.js');
+var BroadcastApp = require('./broadcast.js');
 
 var router = new Grapnel();
 
@@ -37,4 +38,10 @@ router.get('steps/:step', function(req) {
 router.get('injectables/:inj_name', function(req) {
   var inj_name = req.params.inj_name;
   React.render(<InjectableApp inj_name={inj_name} />, content_div());
+});
+
+router.get('broadcasts/:cast/:onto', function(req) {
+  var cast = req.params.cast;
+  var onto = req.params.onto;
+  React.render(<BroadcastApp cast={cast} onto={onto} />, content_div());
 });

--- a/orca/server/static/js/routing.js
+++ b/orca/server/static/js/routing.js
@@ -4,6 +4,7 @@ var React = require('react');
 var SchemaApp = require('./schema.js');
 var TableApp = require('./table.js');
 var ColumnApp = require('./column.js');
+var StepApp = require('./step.js');
 
 var router = new Grapnel();
 
@@ -25,4 +26,9 @@ router.get('tables/:table/columns/:column', function(req) {
   var col_name = req.params.column;
   React.render(
     <ColumnApp table={table_name} column={col_name} />, content_div());
+});
+
+router.get('steps/:step', function(req) {
+  var step_name = req.params.step;
+  React.render(<StepApp step={step_name} />, content_div());
 });

--- a/orca/server/static/js/routing.js
+++ b/orca/server/static/js/routing.js
@@ -1,0 +1,10 @@
+var Grapnel = require('grapnel');
+var React = require('react');
+
+var SchemaApp = require('./schema.js');
+
+var router = new Grapnel();
+
+router.get('', function(req) {
+    React.render(<SchemaApp />, document.getElementById('content'));
+});

--- a/orca/server/static/js/routing.js
+++ b/orca/server/static/js/routing.js
@@ -5,6 +5,7 @@ var SchemaApp = require('./schema.js');
 var TableApp = require('./table.js');
 var ColumnApp = require('./column.js');
 var StepApp = require('./step.js');
+var InjectableApp = require('./injectable.js');
 
 var router = new Grapnel();
 
@@ -31,4 +32,9 @@ router.get('tables/:table/columns/:column', function(req) {
 router.get('steps/:step', function(req) {
   var step_name = req.params.step;
   React.render(<StepApp step={step_name} />, content_div());
+});
+
+router.get('injectables/:inj_name', function(req) {
+  var inj_name = req.params.inj_name;
+  React.render(<InjectableApp inj_name={inj_name} />, content_div());
 });

--- a/orca/server/static/js/schema.js
+++ b/orca/server/static/js/schema.js
@@ -111,11 +111,11 @@ var SchemaApp = React.createClass({
   },
   render: function() {
     return (
-      <div>
+      <div className="schemaApp">
         <div className="page-header">
           <h1>Orca Schema</h1>
         </div>
-        <div className="schemaApp">
+        <div>
           <TableList tables={this.state.tables} />
           <StepList steps={this.state.steps} />
           <InjectableList injectables={this.state.injectables} />

--- a/orca/server/static/js/schema.js
+++ b/orca/server/static/js/schema.js
@@ -1,0 +1,129 @@
+var React = require('react');
+var _ = require('lodash');
+
+var TableList = React.createClass({
+  render: function() {
+    var table_els = _.map(this.props.tables, function(table) {
+      return (
+        <a href={"#tables/" + table} className="list-group-item" key={table}>
+          {table}
+        </a>
+      );
+    });
+
+    return (
+      <section>
+        <h2>Tables</h2>
+        <div className="tableList panel panel-default">
+          <div className="list-group">
+            {table_els}
+          </div>
+        </div>
+      </section>
+    );
+  }
+});
+
+var StepList = React.createClass({
+  render: function() {
+    var step_els = _.map(this.props.steps, function(step) {
+      return (
+        <a href={"#steps/" + step} className="list-group-item" key={step}>
+          {step}
+        </a>
+      );
+    });
+
+    return (
+      <section>
+        <h2>Steps</h2>
+        <div className="stepList panel panel-default">
+          <div className="list-group">
+            {step_els}
+          </div>
+        </div>
+      </section>
+    );
+  }
+});
+
+var InjectableList = React.createClass({
+  render: function() {
+    var inj_els = _.map(this.props.injectables, function(i) {
+      return (
+        <a href={"#injectables/" + i} className="list-group-item" key={i}>
+          {i}
+        </a>
+      );
+    });
+
+    return (
+      <section>
+        <h2>Injectables</h2>
+        <div className="injectableList panel panel-default">
+          <div className="list-group">
+            {inj_els}
+          </div>
+        </div>
+      </section>
+    );
+  }
+});
+
+var BroadcastList = React.createClass({
+  render: function() {
+    var broad_els = _.map(this.props.broadcasts, function(b) {
+      return (
+        <a href={"#broadcasts/" + b.join("/")} className="list-group-item" key={b}>
+          {b[0]} &ndash;&gt; {b[1]}
+        </a>
+      );
+    });
+
+    return (
+      <section>
+        <h2>Broadcasts</h2>
+        <div className="broadcastList panel panel-default">
+          <div className="list-group">
+            {broad_els}
+          </div>
+        </div>
+      </section>
+    );
+  }
+});
+
+var SchemaApp = React.createClass({
+  getInitialState: function() {
+    return {
+      tables: [],
+      cols: {},
+      steps: [],
+      injectables: [],
+      broadcasts: []
+    };
+  },
+  componentDidMount: function() {
+    $.getJSON('/schema')
+      .done(function (data) {
+        this.setState(data);
+      }.bind(this));
+  },
+  render: function() {
+    return (
+      <div>
+        <div className="page-header">
+          <h1>Orca Schema</h1>
+        </div>
+        <div className="schemaApp">
+          <TableList tables={this.state.tables} />
+          <StepList steps={this.state.steps} />
+          <InjectableList injectables={this.state.injectables} />
+          <BroadcastList broadcasts={this.state.broadcasts} />
+        </div>
+      </div>
+    );
+  }
+});
+
+module.exports = SchemaApp;

--- a/orca/server/static/js/step.js
+++ b/orca/server/static/js/step.js
@@ -1,0 +1,27 @@
+// Display information about Orca steps
+var React = require('react');
+
+var funcdef = require('./funcdef.js');
+
+var StepApp = React.createClass({
+  componentDidMount: function() {
+    $.getJSON('/steps/' + this.props.step + '/definition')
+      .done(function(data) {
+        React.render(
+          <funcdef.FuncDefinition funcData={data} />,
+          document.getElementById('step-definition'));
+      });
+  },
+  render: function() {
+    return (
+      <div className="stepApp">
+        <div className="page-header">
+          <h1>{this.props.step}</h1>
+        </div>
+        <div id="step-definition"></div>
+      </div>
+    );
+  }
+});
+
+module.exports = StepApp;

--- a/orca/server/static/js/table.js
+++ b/orca/server/static/js/table.js
@@ -72,8 +72,13 @@ var TableDefinitionDF = React.createClass({
 
 var TableDefinitionFunc = React.createClass({
   render: function() {
+    var f = this.props.funcData;
     return (
-      <div dangerouslySetInnerHTML={{__html: this.props.funcData.html}}>
+      <div className="tableDefinitionFunc">
+        <h3>Source</h3>
+        <p><code>{f.filename} @ line: {f.lineno}</code></p>
+        <div dangerouslySetInnerHTML={{__html: this.props.funcData.html}}>
+        </div>
       </div>
     );
   }

--- a/orca/server/static/js/table.js
+++ b/orca/server/static/js/table.js
@@ -6,6 +6,25 @@ var ViewButtonGroup = require('./buttons.js');
 var funcdef = require('./funcdef.js');
 
 
+var TableInfo = React.createClass({
+  getInitialState: function() {
+    return {info: ''};
+  },
+  componentDidMount: function() {
+    $.get('/tables/' + this.props.table + '/info')
+      .done(function(data) {
+        this.setState({info: data});
+      }.bind(this));
+  },
+  render: function() {
+    return (
+      <div className="tableInfo">
+        <pre>{this.state.info}</pre>
+      </div>
+    );
+  }
+});
+
 var TablePreview = React.createClass({
   componentDidMount: function() {
     $.getJSON('/tables/' + this.props.table + '/preview')
@@ -91,6 +110,7 @@ var TableColumns = React.createClass({
 
 var TableApp = React.createClass({
   tableButtons: [
+    {text: 'Info', view: 'info'},
     {text: 'Preview', view: 'preview'},
     {text: 'Definition', view: 'definition'},
     {text: 'Describe', view: 'describe'},
@@ -108,7 +128,9 @@ var TableApp = React.createClass({
     var view = this.state.view;
     var table = this.props.table;
 
-    if (view === 'preview') {
+    if (view === 'info') {
+      var tableComponent = <TableInfo table={table} />;
+    } else if (view === 'preview') {
       var tableComponent = <TablePreview table={table} />;
     } else if (view === 'definition') {
       var tableComponent = <TableDefinition table={table} />;

--- a/orca/server/static/js/table.js
+++ b/orca/server/static/js/table.js
@@ -64,10 +64,37 @@ var TablePreview = React.createClass({
   }
 });
 
-var TableDefinition = React.createClass({
+var TableDefinitionDF = React.createClass({
+  render: function() {
+    return (<p>DataFrame</p>);
+  }
+});
+
+var TableDefinitionFunc = React.createClass({
   render: function() {
     return (
-      <div><p>{this.props.table}</p></div>
+      <div dangerouslySetInnerHTML={{__html: this.props.funcData.html}}>
+      </div>
+    );
+  }
+});
+
+var TableDefinition = React.createClass({
+  componentDidMount: function() {
+    $.getJSON('/tables/' + this.props.table + '/definition')
+      .done(function(data) {
+        if (data.type === 'dataframe') {
+          var component = <TableDefinitionDF />;
+        } else if (data.type === 'function') {
+          var component = <TableDefinitionFunc funcData={data} />;
+        }
+
+        React.render(component, document.getElementById('table-definition'));
+      });
+  },
+  render: function() {
+    return (
+      <div id="table-definition"></div>
     );
   }
 });

--- a/orca/server/static/js/table.js
+++ b/orca/server/static/js/table.js
@@ -1,52 +1,9 @@
 var React = require('react');
-var classNames = require('classnames');
 var _ = require('lodash');
+
 var dtopts = require('./dtopts.js');
+var ViewButtonGroup = require('./buttons.js');
 
-
-var TableButton = React.createClass({
-  clickHandler: function(event) {
-    this.props.clickHandler(this.props.view);
-  },
-  render: function() {
-    var classes = classNames({
-      "btn": true,
-      "btn-default": true,
-      "active": this.props.active
-    });
-
-    return (
-      <button
-          type="button"
-          className={classes}
-          onClick={this.clickHandler}>
-        {this.props.text}
-      </button>
-    );
-  }
-});
-
-var TableButtons = React.createClass({
-  render: function() {
-    var button_els = _.map(this.props.buttons, function(b) {
-      return (
-        <TableButton
-          text={b.text}
-          view={b.view}
-          key={b.view}
-          active={b.view === this.props.view}
-          clickHandler={this.props.clickHandler}
-        />
-      );
-    }.bind(this));
-
-    return (
-      <div className="tableButtons btn-group" role="group">
-        {button_els}
-      </div>
-    );
-  }
-});
 
 var TablePreview = React.createClass({
   componentDidMount: function() {
@@ -185,7 +142,7 @@ var TableApp = React.createClass({
         <div className="page-header">
           <h1>{this.props.table}</h1>
         </div>
-        <TableButtons
+        <ViewButtonGroup
             buttons={this.tableButtons}
             view={this.state.view}
             clickHandler={this.handleButtonClick} />

--- a/orca/server/static/js/table.js
+++ b/orca/server/static/js/table.js
@@ -1,22 +1,45 @@
 var React = require('react');
+var classNames = require('classnames');
 var _ = require('lodash');
 var dtopts = require('./dtopts.js');
 
 
+var TableButton = React.createClass({
+  clickHandler: function(event) {
+    this.props.clickHandler(this.props.view);
+  },
+  render: function() {
+    var classes = classNames({
+      "btn": true,
+      "btn-default": true,
+      "active": this.props.active
+    });
+
+    return (
+      <button
+          type="button"
+          className={classes}
+          onClick={this.clickHandler}
+          data-view={this.props.view}>
+        {this.props.text}
+      </button>
+    );
+  }
+});
+
 var TableButtons = React.createClass({
   render: function() {
-    var buttons = [['Preview', 'preview']];
-    var button_els = _.map(buttons, function(b, i) {
-        var classes = "btn btn-default";
-        if (i === 0) {
-          classes += " active";
-        }
+    var button_els = _.map(this.props.buttons, function(b) {
       return (
-        <button type="button" className={classes} key={b[1]}>
-          {b[0]}
-        </button>
+        <TableButton
+          text={b[0]}
+          view={b[1]}
+          key={b[1]}
+          active={b[1] === this.props.view ? true : false}
+          clickHandler={this.props.clickHandler}
+        />
       );
-    });
+    }.bind(this));
 
     return (
       <div className="tableButtons btn-group" role="group">
@@ -42,15 +65,42 @@ var TablePreview = React.createClass({
   }
 });
 
-var TableApp = React.createClass({
+var TableDefinition = React.createClass({
   render: function() {
+    return (
+      <div><p>{this.props.table}</p></div>
+    );
+  }
+});
+
+var TableApp = React.createClass({
+  tableButtons: [['Preview', 'preview'], ['Definition', 'definition']],
+  getInitialState: function() {
+    return {view: this.tableButtons[0][1]};
+  },
+  handleButtonClick: function(view) {
+    if (view !== this.state.view) {
+      this.setState({view: view});
+    }
+  },
+  render: function() {
+    var view = this.state.view;
+    if (view === 'preview') {
+      var tableComponent = <TablePreview table={this.props.table} />;
+    } else if (view === 'definition') {
+      var tableComponent = <TableDefinition table={this.props.table} />;
+    }
+
     return (
       <div className="tableApp">
         <div className="page-header">
           <h1>{this.props.table}</h1>
         </div>
-        <TableButtons />
-        <TablePreview table={this.props.table} />
+        <TableButtons
+            buttons={this.tableButtons}
+            view={this.state.view}
+            clickHandler={this.handleButtonClick} />
+        {tableComponent}
       </div>
     );
   }

--- a/orca/server/static/js/table.js
+++ b/orca/server/static/js/table.js
@@ -1,0 +1,59 @@
+var React = require('react');
+var _ = require('lodash');
+var dtopts = require('./dtopts.js');
+
+
+var TableButtons = React.createClass({
+  render: function() {
+    var buttons = [['Preview', 'preview']];
+    var button_els = _.map(buttons, function(b, i) {
+        var classes = "btn btn-default";
+        if (i === 0) {
+          classes += " active";
+        }
+      return (
+        <button type="button" className={classes} key={b[1]}>
+          {b[0]}
+        </button>
+      );
+    });
+
+    return (
+      <div className="tableButtons btn-group" role="group">
+        {button_els}
+      </div>
+    );
+  }
+});
+
+var TablePreview = React.createClass({
+  componentDidMount: function() {
+    $.getJSON('/tables/' + this.props.table + '/preview')
+      .done(function(data) {
+        $('#preview-table').DataTable(dtopts(data));
+      });
+  },
+  render: function() {
+    return (
+      <div>
+        <table className="display" id="preview-table">
+        </table>
+      </div>);
+  }
+});
+
+var TableApp = React.createClass({
+  render: function() {
+    return (
+      <div className="tableApp">
+        <div className="page-header">
+          <h1>{this.props.table}</h1>
+        </div>
+        <TableButtons />
+        <TablePreview table={this.props.table} />
+      </div>
+    );
+  }
+});
+
+module.exports = TableApp;

--- a/orca/server/static/js/table.js
+++ b/orca/server/static/js/table.js
@@ -19,8 +19,7 @@ var TableButton = React.createClass({
       <button
           type="button"
           className={classes}
-          onClick={this.clickHandler}
-          data-view={this.props.view}>
+          onClick={this.clickHandler}>
         {this.props.text}
       </button>
     );
@@ -32,10 +31,10 @@ var TableButtons = React.createClass({
     var button_els = _.map(this.props.buttons, function(b) {
       return (
         <TableButton
-          text={b[0]}
-          view={b[1]}
-          key={b[1]}
-          active={b[1] === this.props.view ? true : false}
+          text={b.text}
+          view={b.view}
+          key={b.view}
+          active={b.view === this.props.view}
           clickHandler={this.props.clickHandler}
         />
       );
@@ -74,9 +73,12 @@ var TableDefinition = React.createClass({
 });
 
 var TableApp = React.createClass({
-  tableButtons: [['Preview', 'preview'], ['Definition', 'definition']],
+  tableButtons: [
+    {text: 'Preview', view: 'preview'},
+    {text: 'Definition', view: 'definition'}
+  ],
   getInitialState: function() {
-    return {view: this.tableButtons[0][1]};
+    return {view: this.tableButtons[0].view};
   },
   handleButtonClick: function(view) {
     if (view !== this.state.view) {

--- a/orca/server/static/js/table.js
+++ b/orca/server/static/js/table.js
@@ -121,11 +121,42 @@ var TableDescribe = React.createClass({
   }
 });
 
+var TableColumns = React.createClass({
+  getInitialState: function() {
+    return {columns: []};
+  },
+  componentDidMount: function() {
+    $.getJSON('/tables/' + this.props.table + '/columns')
+      .done(function(data) {
+        this.setState(data);
+      }.bind(this));
+  },
+  render: function() {
+    var col_els = _.map(this.state.columns, function(col) {
+      return (
+        <a
+            href={'#tables/' + this.props.table + '/columns/' + col}
+            className="list-group-item"
+            key={this.props.table + '.' + col}>
+          {col}
+        </a>
+      );
+    }.bind(this));
+
+    return (
+      <div className="tableColumns list-group">
+        {col_els}
+      </div>
+    );
+  }
+});
+
 var TableApp = React.createClass({
   tableButtons: [
     {text: 'Preview', view: 'preview'},
     {text: 'Definition', view: 'definition'},
-    {text: 'Describe', view: 'describe'}
+    {text: 'Describe', view: 'describe'},
+    {text: 'Columns', view: 'columns'}
   ],
   getInitialState: function() {
     return {view: this.tableButtons[0].view};
@@ -145,6 +176,8 @@ var TableApp = React.createClass({
       var tableComponent = <TableDefinition table={table} />;
     } else if (view === 'describe') {
       var tableComponent = <TableDescribe table={table} />;
+    } else if (view === 'columns') {
+      var tableComponent = <TableColumns table={table} />;
     }
 
     return (

--- a/orca/server/static/js/table.js
+++ b/orca/server/static/js/table.js
@@ -57,7 +57,7 @@ var TablePreview = React.createClass({
   },
   render: function() {
     return (
-      <div>
+      <div className="tablePreview">
         <table className="display" id="preview-table">
         </table>
       </div>);
@@ -104,10 +104,28 @@ var TableDefinition = React.createClass({
   }
 });
 
+var TableDescribe = React.createClass({
+  componentDidMount: function() {
+    $.getJSON('/tables/' + this.props.table + '/describe')
+      .done(function(data) {
+        $('#describe-table').DataTable(dtopts(data));
+      });
+  },
+  render: function() {
+    return (
+      <div className="tableDescribe">
+        <table className="display" id="describe-table">
+        </table>
+      </div>
+    );
+  }
+});
+
 var TableApp = React.createClass({
   tableButtons: [
     {text: 'Preview', view: 'preview'},
-    {text: 'Definition', view: 'definition'}
+    {text: 'Definition', view: 'definition'},
+    {text: 'Describe', view: 'describe'}
   ],
   getInitialState: function() {
     return {view: this.tableButtons[0].view};
@@ -119,10 +137,14 @@ var TableApp = React.createClass({
   },
   render: function() {
     var view = this.state.view;
+    var table = this.props.table;
+
     if (view === 'preview') {
-      var tableComponent = <TablePreview table={this.props.table} />;
+      var tableComponent = <TablePreview table={table} />;
     } else if (view === 'definition') {
-      var tableComponent = <TableDefinition table={this.props.table} />;
+      var tableComponent = <TableDefinition table={table} />;
+    } else if (view === 'describe') {
+      var tableComponent = <TableDescribe table={table} />;
     }
 
     return (

--- a/orca/server/static/js/table.js
+++ b/orca/server/static/js/table.js
@@ -3,6 +3,7 @@ var _ = require('lodash');
 
 var dtopts = require('./dtopts.js');
 var ViewButtonGroup = require('./buttons.js');
+var funcdef = require('./funcdef.js');
 
 
 var TablePreview = React.createClass({
@@ -21,34 +22,14 @@ var TablePreview = React.createClass({
   }
 });
 
-var TableDefinitionDF = React.createClass({
-  render: function() {
-    return (<p>DataFrame</p>);
-  }
-});
-
-var TableDefinitionFunc = React.createClass({
-  render: function() {
-    var f = this.props.funcData;
-    return (
-      <div className="tableDefinitionFunc">
-        <h3>Source</h3>
-        <p><code>{f.filename} @ line: {f.lineno}</code></p>
-        <div dangerouslySetInnerHTML={{__html: this.props.funcData.html}}>
-        </div>
-      </div>
-    );
-  }
-});
-
 var TableDefinition = React.createClass({
   componentDidMount: function() {
     $.getJSON('/tables/' + this.props.table + '/definition')
       .done(function(data) {
         if (data.type === 'dataframe') {
-          var component = <TableDefinitionDF />;
+          var component = <funcdef.LiteralDefinition text="DataFrame" />;
         } else if (data.type === 'function') {
-          var component = <TableDefinitionFunc funcData={data} />;
+          var component = <funcdef.FuncDefinition funcData={data} />;
         }
 
         React.render(component, document.getElementById('table-definition'));

--- a/orca/server/static/js/table.js
+++ b/orca/server/static/js/table.js
@@ -9,7 +9,7 @@ var TablePreview = React.createClass({
   componentDidMount: function() {
     $.getJSON('/tables/' + this.props.table + '/preview')
       .done(function(data) {
-        $('#preview-table').DataTable(dtopts(data));
+        $('#preview-table').DataTable(dtopts.table_opts(data));
       });
   },
   render: function() {
@@ -65,7 +65,7 @@ var TableDescribe = React.createClass({
   componentDidMount: function() {
     $.getJSON('/tables/' + this.props.table + '/describe')
       .done(function(data) {
-        $('#describe-table').DataTable(dtopts(data));
+        $('#describe-table').DataTable(dtopts.table_opts(data));
       });
   },
   render: function() {

--- a/orca/server/static/package.json
+++ b/orca/server/static/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "dependencies": {
     "URIjs": "^1.15.1",
+    "classnames": "^2.1.2",
     "grapnel": "^0.5.8",
     "lodash": "^3.9.3",
     "react": "^0.13.3"

--- a/orca/server/static/package.json
+++ b/orca/server/static/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "Orca-UI",
+  "version": "0.1.0",
+  "dependencies": {
+    "URIjs": "^1.15.1",
+    "grapnel": "^0.5.8",
+    "lodash": "^3.9.3",
+    "react": "^0.13.3"
+  },
+  "devDependencies": {
+    "browserify": "^10.2.4",
+    "gulp": "^3.9.0",
+    "gulp-streamify": "0.0.5",
+    "gulp-util": "^3.0.5",
+    "lodash": "^3.9.3",
+    "reactify": "^1.1.1",
+    "vinyl-source-stream": "^1.1.0",
+    "watchify": "^3.2.2"
+  }
+}

--- a/orca/server/templates/ui.html
+++ b/orca/server/templates/ui.html
@@ -11,6 +11,9 @@
     <!-- Latest compiled and minified CSS -->
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css">
 
+    <!-- Pygments CSS -->
+    <link rel="stylesheet" href="/static/css/pygments.css">
+
     <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
     <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
     <!--[if lt IE 9]>

--- a/orca/server/templates/ui.html
+++ b/orca/server/templates/ui.html
@@ -14,6 +14,9 @@
     <!-- Pygments CSS -->
     <link rel="stylesheet" href="/static/css/pygments.css">
 
+    <!-- DataTables CSS -->
+    <link rel="stylesheet" href="https://cdn.datatables.net/1.10.7/css/jquery.dataTables.css">
+
     <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
     <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
     <!--[if lt IE 9]>
@@ -32,6 +35,9 @@
     <script src="https://code.jquery.com/jquery-1.11.3.min.js"></script>
     <!-- Latest compiled and minified JavaScript -->
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js"></script>
+    <!-- DataTables JS -->
+    <!-- For some reason this doesn't play well with browserify. -->
+    <script src="https://cdn.datatables.net/1.10.7/js/jquery.dataTables.min.js"></script>
     <!-- Orca UI App JS -->
     <script src="/static/js/dist/bundle.js"></script>
   </body>

--- a/orca/server/templates/ui.html
+++ b/orca/server/templates/ui.html
@@ -9,7 +9,7 @@
 
     <!-- Bootstrap -->
     <!-- Latest compiled and minified CSS -->
-    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css">
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css">
 
     <!-- Pygments CSS -->
     <link rel="stylesheet" href="/static/css/pygments.css">
@@ -34,7 +34,7 @@
     <!-- jQuery (necessary for Bootstrap's JavaScript plugins) -->
     <script src="https://code.jquery.com/jquery-1.11.3.min.js"></script>
     <!-- Latest compiled and minified JavaScript -->
-    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js"></script>
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/js/bootstrap.min.js"></script>
     <!-- DataTables JS -->
     <!-- For some reason this doesn't play well with browserify. -->
     <script src="https://cdn.datatables.net/1.10.7/js/jquery.dataTables.min.js"></script>

--- a/orca/server/templates/ui.html
+++ b/orca/server/templates/ui.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <!-- The above 3 meta tags *must* come first in the head; any other head content must come *after* these tags -->
+    <title>Orca</title>
+
+    <!-- Bootstrap -->
+    <!-- Latest compiled and minified CSS -->
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css">
+
+    <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
+    <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
+    <!--[if lt IE 9]>
+      <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
+      <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
+    <![endif]-->
+  </head>
+  <body>
+    <div class="container">
+      <div id="content">
+        <p>Loading...</p>
+      </div>
+    </div>
+
+    <!-- jQuery (necessary for Bootstrap's JavaScript plugins) -->
+    <script src="https://code.jquery.com/jquery-1.11.3.min.js"></script>
+    <!-- Latest compiled and minified JavaScript -->
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js"></script>
+    <!-- Orca UI App JS -->
+    <script src="/static/js/dist/bundle.js"></script>
+  </body>
+</html>

--- a/orca/server/tests/test_server.py
+++ b/orca/server/tests/test_server.py
@@ -104,6 +104,15 @@ def test_list_tables(tapp):
     assert set(data['tables']) == {'dfa', 'dfb'}
 
 
+def test_table_info(tapp):
+    rv = tapp.get('/tables/dfa/info')
+    assert rv.status_code == 200
+
+    data = rv.data.decode('utf-8')
+
+    assert 'extra_acol' in data
+
+
 def test_table_preview(tapp):
     rv = tapp.get('/tables/dfa/preview')
     assert rv.status_code == 200

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
         'zbox >= 1.2'
     ],
     extras_require={
-        'server': ['flask >= 0.10', 'pygments >= 2.0']
+        'server': ['flask >= 0.10', 'pygments >= 2.0', 'six >= 1.9.0']
     },
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
Users can now launch the orca server and point their browsers at the `/ui` route to browse a read-only view of all aspects of their configuration.

The sphinx docs now include a page about the Orca server and all its endpoints.

The `orca-server` command line entry point has been expanded to include options for setting the hostname and port.